### PR TITLE
Found unwanted behavior in #215 in various places: 

### DIFF
--- a/src/sensordatainterface/templates/equipment/factory-service/details.html
+++ b/src/sensordatainterface/templates/equipment/factory-service/details.html
@@ -68,7 +68,12 @@
 
                 <tr>
                     <th>Owner Name:</th>
-                    <td>{{ FactoryService.equipmentid.equipmentownerid.personfirstname }} {{ FactoryService.equipmentid.equipmentownerid.personlastname }}</td>
+                    <td>
+                        <a href="{% url 'person_detail' FactoryService.equipmentid.equipmentownerid.personid %}">
+                            {{ FactoryService.equipmentid.equipmentownerid.personfirstname }}
+                            {{ FactoryService.equipmentid.equipmentownerid.personlastname|default:" -- " }}
+                        </a>
+                    </td>
                 </tr>
             </table>
             </div>

--- a/src/sensordatainterface/templates/equipment/models/details.html
+++ b/src/sensordatainterface/templates/equipment/models/details.html
@@ -92,7 +92,12 @@
                                 {{ equipment.equipmentmodelid.modelmanufacturerid.organizationname|default:" -- " }}
                             </a>
                         </td>
-                        <td>{{ equipment.equipmentownerid.personfirstname }} {{ equipment.equipmentownerid.personlastname }}</td>
+                        <td>
+                        <a href="{% url 'person_detail' equipment.equipmentownerid.personid %}">
+                            {{ equipment.equipmentownerid.personfirstname }}
+                            {{ equipment.equipmentownerid.personlastname|default:" -- " }}
+                        </a>
+                        </td>
                     </tr>
                 {% endfor %}
                 </tbody>

--- a/src/sensordatainterface/templates/people/organization-detail.html
+++ b/src/sensordatainterface/templates/people/organization-detail.html
@@ -93,7 +93,12 @@
                     <td>{{ equipment.equipmenttypecv }}</td>
                     <td>{{ equipment.equipmentmodelid.modelname }}</td>
                     <td>{{ equipment.equipmentmodelid.modelmanufacturerid.organizationname }}</td>
-                    <td>{{ equipment.equipmentownerid.personfirstname }} {{ equipment.equipmentownerid.personlastname }}</td>
+                    <td>
+                        <a href="{% url 'person_detail' equipment.equipmentownerid.personid %}">
+                            {{ equipment.equipmentownerid.personfirstname }}
+                            {{ equipment.equipmentownerid.personlastname|default:" -- " }}
+                        </a>
+                    </td>
                 </tr>
             {% endfor %}
             </tbody>

--- a/src/sensordatainterface/templates/site-visits/calibration/details.html
+++ b/src/sensordatainterface/templates/site-visits/calibration/details.html
@@ -107,7 +107,7 @@
                     <th>Owner Name:</th>
 
                     <td>
-                        <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.affiliation.all.0.affiliationid %}">
+                        <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.personid %}">
                             {{ equipment.equipmentid.equipmentownerid.personfirstname }}
                             {{ equipment.equipmentid.equipmentownerid.personlastname|default:" -- " }}
                         </a>

--- a/src/sensordatainterface/templates/site-visits/deployment/retrieval_details.html
+++ b/src/sensordatainterface/templates/site-visits/deployment/retrieval_details.html
@@ -108,7 +108,7 @@
                                         </td>
                                         <th>Equipment Owner</th>
                                         <td>
-                                            <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.affiliation.get.affiliationid %}">
+                                            <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.personid %}">
                                                 {{ equipment.equipmentid.equipmentownerid.personfirstname }} {{ equipment.equipmentid.equipmentownerid.personlastname }}</a>
                                         </td>
                                         <th>Purchase Date</th>

--- a/src/sensordatainterface/templates/site-visits/details.html
+++ b/src/sensordatainterface/templates/site-visits/details.html
@@ -40,7 +40,7 @@
                 <tr>
                     <th>People:</th>
                     <td>{% for person in SiteVisit.actionid.actionby.all %}
-                        <a href="{% url 'person_detail' person.affiliationid_id %}">{{ person.affiliationid.personid.personfirstname }}
+                        <a href="{% url 'person_detail' person.affiliationid.personid.personid %}">{{ person.affiliationid.personid.personfirstname }}
                         {{ person.affiliationid.personid.personlastname }}</a>
                         {% if not forloop.last %}, {% endif %}
                     {% endfor %}</td>

--- a/src/sensordatainterface/templates/site-visits/field-activities/details.html
+++ b/src/sensordatainterface/templates/site-visits/field-activities/details.html
@@ -38,7 +38,7 @@
                     <td>{% for related in Activity.actionid.relatedaction.all %}
                         {% if related.relationshiptypecv_id == 'Is child of' %}
                             {% for person in related.relatedactionid.actionby.all %}
-                                <a href="{% url 'person_detail' person.affiliationid_id %}">
+                                <a href="{% url 'person_detail' person.affiliationid.personid.personid %}">
                                     {{ person.affiliationid.personid.personfirstname }}
                                     {{ person.affiliationid.personid.personlastname|default:" -- " }}
                                 </a>
@@ -171,7 +171,7 @@
                                 </td>
                                 <th>Equipment Owner</th>
                                 <td>
-                                    <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.affiliation.all.0.affiliationid %}">
+                                    <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.personid %}">
                                         {{ equipment.equipmentid.equipmentownerid.personfirstname }} {{ equipment.equipmentid.equipmentownerid.personlastname }}</a>
                                 </td>
                                 <th>Purchase Date</th>

--- a/src/sensordatainterface/templates/site-visits/results/details.html
+++ b/src/sensordatainterface/templates/site-visits/results/details.html
@@ -77,7 +77,7 @@
                                 <th>Owner Name:</th>
 
                                 <td>
-                                    <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.affiliation.all.0.affiliationid %}">
+                                    <a href="{% url 'person_detail' equipment.equipmentid.equipmentownerid.personid %}">
                                         {{ equipment.equipmentid.equipmentownerid.personfirstname }}
                                         {{ equipment.equipmentid.equipmentownerid.personlastname|default:" -- " }}
                                     </a>


### PR DESCRIPTION
Calibration Details, field-activity Details, Results Details, Organization Details (Also added hyperlink to owner, it had not been implemented on this page),  Retrieval Details, and factory-service Details, Site Visits Details. Fixed each of these templates. I suspect I will need to fix more, but haven't found them yet.