### PR TITLE
Fixed #222 

### DIFF
--- a/src/sensordatainterface/views/edit_views.py
+++ b/src/sensordatainterface/views/edit_views.py
@@ -1221,7 +1221,7 @@ def edit_retrieval(request, deployment_id=None, retrieval_id=None):
 
     if request.method == 'POST':
         updating = request.POST['action'] == 'update'
-        deployment_action = Action.objects.get(pk=request.POST['deploymentaction'])
+        deployment_action = Action.objects.get(pk=request.POST.get('deployment_id'))
 
         if updating:
             site_visit = Action.objects.get(pk=request.POST['actionid'])


### PR DESCRIPTION
Not sure why but the retrieval view was trying to get an action object via primary key, by searching for a field that didn't exist in the POST request. Fixed and is now working locally. 